### PR TITLE
Release 2.1.7

### DIFF
--- a/lib/assets/css/style-front.css
+++ b/lib/assets/css/style-front.css
@@ -1223,10 +1223,11 @@ Epl fancy pagination
 		padding-top: 0.5em;
 		padding-left: 0;
 	}
-	
+	.epl-property-single.view-expanded .entry-header .property-details,
 	.epl-property-single.view-expanded .property-details {
 	width: 100%;
 	}
+	.epl-property-single.view-expanded .entry-header .property-pricing-details,
 	.epl-property-single.view-expanded .property-pricing-details{
 		width: 100%;
 	}

--- a/lib/assets/css/style-front.css
+++ b/lib/assets/css/style-front.css
@@ -135,6 +135,10 @@ h3.property-address {
 	text-decoration: none;
 	background: #888888;
 }
+.epl-floor-plan-button-wrapper {
+	display: inline-block;
+	margin-right: 0.3em;
+}
 /*** Override theme button styles ***/
 .epl-button a,
 .epl-button input[type='submit'], 

--- a/lib/assets/index.php
+++ b/lib/assets/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/compatibility/extensions.php
+++ b/lib/compatibility/extensions.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+ * Staff Directory Compatibility
+ */
 function epl_sd_author_box_compat() {
 	if(has_action( 'epl_single_author' , 'epl_sd_advanced_author_box' ) || has_action( 'epl_single_author' , 'epl_sd_advanced_author_box_tabs' )) {
 		remove_action( 'epl_single_author','epl_property_author_box' );

--- a/lib/compatibility/functions-compat.php
+++ b/lib/compatibility/functions-compat.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Get EPL author meta
  *

--- a/lib/compatibility/listing-meta-compat.php
+++ b/lib/compatibility/listing-meta-compat.php
@@ -1,11 +1,11 @@
 ﻿<?php
-/*
+/**
  * Function to retrieve property or rental custom fields.
  */
  
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
- 
+
 //Global
 global $post;
 $epl_settings = epl_settings(); 

--- a/lib/hooks/index.php
+++ b/lib/hooks/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/includes/EPL_SL_Plugin_Updater.php
+++ b/lib/includes/EPL_SL_Plugin_Updater.php
@@ -1,5 +1,4 @@
 <?php
-
 // uncomment this line for testing
 //set_site_transient( 'update_plugins', null );
 

--- a/lib/includes/class-author-meta.php
+++ b/lib/includes/class-author-meta.php
@@ -1,8 +1,7 @@
 <?php
-
 /*
-*	@since version 1.3
-*/
+ * @since version 1.3
+ */
 
 class EPL_Author_Meta {
 	

--- a/lib/includes/index.php
+++ b/lib/includes/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -1028,7 +1028,7 @@ function epl_author_tab_author_id($epl_author = array() ) {
 		</h5>
 		<div class="author-position">
 			<span class="label-position"></span>
-			<span class="mobile"><?php echo $epl_author->get_author_position() ?></span>
+			<span class="position"><?php echo $epl_author->get_author_position() ?></span>
 		</div>
 
 		<div class="author-contact">

--- a/lib/index.php
+++ b/lib/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/languages/epl.pot
+++ b/lib/languages/epl.pot
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Easy Property Listings 1.1.2\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2015-05-05 11:29+0800\n"
-"PO-Revision-Date: 2015-05-05 11:29+0800\n"
+"POT-Creation-Date: 2015-05-06 17:51+0800\n"
+"PO-Revision-Date: 2015-05-06 17:51+0800\n"
 "Last-Translator: Merv Barrett <admin@realestateconnected.com.au>\n"
 "Language-Team: Real Estate Connected <admin@realestateconnected.com.au>\n"
 "Language: en\n"
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 
 #: compatibility/author-meta-compat.php:28 includes/class-author-meta.php:57
-#: includes/template-functions.php:1005
+#: includes/template-functions.php:997
 msgid "Contact"
 msgstr ""
 
@@ -95,12 +95,13 @@ msgstr ""
 #: includes/class-property-meta.php:336 includes/class-property-meta.php:384
 #: includes/class-property-meta.php:426 includes/class-property-meta.php:465
 #: includes/class-property-meta.php:481 includes/class-property-meta.php:516
-#: includes/template-functions.php:685 meta-boxes/meta-boxes.php:35
+#: includes/template-functions.php:677 meta-boxes/meta-boxes.php:35
 #: post-types/post-type-business.php:285 post-types/post-type-commercial.php:278
 #: post-types/post-type-commercial_land.php:270 post-types/post-type-land.php:239
 #: post-types/post-type-property.php:254 post-types/post-type-rental.php:256
 #: post-types/post-type-rural.php:262 post-types/post-types.php:45
 #: widgets/widget-admin-dashboard.php:119 widgets/widget-admin-dashboard.php:141
+#: widgets/widget-listing-search.php:163
 msgid "Sold"
 msgstr ""
 
@@ -120,6 +121,7 @@ msgstr ""
 #: includes/install.php:60 includes/install.php:96 meta-boxes/meta-boxes.php:39
 #: post-types/post-types.php:49 updates/epl-2.1.php:5
 #: widgets/widget-admin-dashboard.php:100 widgets/widget-admin-dashboard.php:120
+#: widgets/widget-listing-search.php:164
 msgid "Leased"
 msgstr ""
 
@@ -133,7 +135,7 @@ msgid "Commercial Category"
 msgstr ""
 
 #: compatibility/listing-meta-compat.php:572 meta-boxes/meta-boxes.php:1296
-#: shortcodes/shortcode-listing-search.php:461
+#: shortcodes/shortcode-listing-search.php:473
 msgid "Car Spaces"
 msgstr ""
 
@@ -180,7 +182,7 @@ msgid "bed"
 msgstr ""
 
 #: compatibility/listing-meta-compat.php:655 includes/class-property-meta.php:570
-#: meta-boxes/meta-boxes.php:293 shortcodes/shortcode-listing-search.php:402
+#: meta-boxes/meta-boxes.php:293 shortcodes/shortcode-listing-search.php:414
 msgid "Bathrooms"
 msgstr ""
 
@@ -192,7 +194,7 @@ msgstr ""
 #: compatibility/listing-meta-compat.php:660 includes/class-property-meta.php:580
 #: meta-boxes/meta-boxes.php:300 post-types/post-type-property.php:155
 #: post-types/post-type-rental.php:154 post-types/post-type-rural.php:158
-#: shortcodes/shortcode-listing-search.php:431 widgets/widget-listing-search.php:175
+#: shortcodes/shortcode-listing-search.php:443 widgets/widget-listing-search.php:200
 msgid "Rooms"
 msgstr ""
 
@@ -207,7 +209,7 @@ msgid "Parking Spaces"
 msgstr ""
 
 #: compatibility/listing-meta-compat.php:668 includes/class-property-meta.php:626
-#: meta-boxes/meta-boxes.php:363 shortcodes/shortcode-listing-search.php:623
+#: meta-boxes/meta-boxes.php:363 shortcodes/shortcode-listing-search.php:635
 msgid "Air Conditioning"
 msgstr ""
 
@@ -217,7 +219,7 @@ msgstr ""
 
 #: compatibility/listing-meta-compat.php:672 compatibility/listing-meta-compat.php:673
 #: includes/class-property-meta.php:638 includes/class-property-meta.php:639
-#: meta-boxes/meta-boxes.php:353 shortcodes/shortcode-listing-search.php:630
+#: meta-boxes/meta-boxes.php:353 shortcodes/shortcode-listing-search.php:642
 msgid "Pool"
 msgstr ""
 
@@ -482,25 +484,25 @@ msgstr ""
 msgid " Car Spaces"
 msgstr ""
 
-#: includes/functions.php:122 menus/menu-welcome.php:665
+#: includes/functions.php:122 menus/menu-welcome.php:669
 msgid "Property (Residential)"
 msgstr ""
 
 #: includes/functions.php:123 includes/functions.php:1065 includes/install.php:62
-#: includes/install.php:98 menus/menu-welcome.php:667 post-types/post-type-land.php:28
+#: includes/install.php:98 menus/menu-welcome.php:671 post-types/post-type-land.php:28
 #: post-types/post-type-land.php:29 post-types/post-type-land.php:30
 #: updates/epl-1.3.1.php:5 widgets/widget-admin-dashboard.php:55
 msgid "Land"
 msgstr ""
 
-#: includes/functions.php:124 includes/functions.php:1071 menus/menu-welcome.php:666
+#: includes/functions.php:124 includes/functions.php:1071 menus/menu-welcome.php:670
 #: post-types/post-type-rental.php:29 updates/epl-1.3.1.php:6
 #: widgets/widget-admin-dashboard.php:58
 msgid "Rental"
 msgstr ""
 
 #: includes/functions.php:125 includes/functions.php:1077 includes/install.php:64
-#: includes/install.php:100 menus/menu-welcome.php:668
+#: includes/install.php:100 menus/menu-welcome.php:672
 #: post-types/post-type-rural.php:28 post-types/post-type-rural.php:29
 #: post-types/post-type-rural.php:30 updates/epl-1.3.1.php:7
 #: widgets/widget-admin-dashboard.php:61
@@ -508,21 +510,21 @@ msgid "Rural"
 msgstr ""
 
 #: includes/functions.php:126 includes/functions.php:392 includes/functions.php:1083
-#: includes/install.php:66 includes/install.php:102 menus/menu-welcome.php:669
+#: includes/install.php:66 includes/install.php:102 menus/menu-welcome.php:673
 #: post-types/post-type-commercial.php:29 updates/epl-1.3.1.php:9
 #: widgets/widget-admin-dashboard.php:64
 msgid "Commercial"
 msgstr ""
 
 #: includes/functions.php:127 includes/functions.php:1089 includes/install.php:67
-#: includes/install.php:103 menus/menu-welcome.php:670
+#: includes/install.php:103 menus/menu-welcome.php:674
 #: post-types/post-type-commercial_land.php:30 updates/epl-1.3.1.php:10
 #: widgets/widget-admin-dashboard.php:67
 msgid "Commercial Land"
 msgstr ""
 
 #: includes/functions.php:128 includes/functions.php:1095 includes/install.php:65
-#: includes/install.php:101 menus/menu-welcome.php:671
+#: includes/install.php:101 menus/menu-welcome.php:675
 #: post-types/post-type-business.php:30 updates/epl-1.3.1.php:8
 #: widgets/widget-admin-dashboard.php:70
 msgid "Business"
@@ -950,11 +952,11 @@ msgstr ""
 msgid "Archive View: listing view type"
 msgstr ""
 
-#: includes/functions.php:961 includes/template-functions.php:1149
+#: includes/functions.php:961 includes/template-functions.php:1141
 msgid "List"
 msgstr ""
 
-#: includes/functions.php:962 includes/template-functions.php:1151
+#: includes/functions.php:962 includes/template-functions.php:1143
 msgid "Grid"
 msgstr ""
 
@@ -1123,56 +1125,56 @@ msgstr ""
 msgid "Recently Leased"
 msgstr ""
 
-#: includes/template-functions.php:631 includes/template-functions.php:804
+#: includes/template-functions.php:623 includes/template-functions.php:796
 #: meta-boxes/meta-boxes.php:1249
 msgid "Plus Outgoings"
 msgstr ""
 
-#: includes/template-functions.php:645 includes/template-functions.php:798
+#: includes/template-functions.php:637 includes/template-functions.php:790
 msgid "Available from"
 msgstr ""
 
-#: includes/template-functions.php:781
+#: includes/template-functions.php:773
 msgid "Property Features"
 msgstr ""
 
-#: includes/template-functions.php:836 meta-boxes/meta-boxes.php:1270
+#: includes/template-functions.php:828 meta-boxes/meta-boxes.php:1270
 msgid "Commercial Features"
 msgstr ""
 
-#: includes/template-functions.php:862 meta-boxes/meta-boxes.php:1102
+#: includes/template-functions.php:854 meta-boxes/meta-boxes.php:1102
 msgid "Rural Features"
 msgstr ""
 
-#: includes/template-functions.php:934
+#: includes/template-functions.php:926
 msgid "Sort"
 msgstr ""
 
-#: includes/template-functions.php:935
+#: includes/template-functions.php:927
 msgid "Price: High to Low"
 msgstr ""
 
-#: includes/template-functions.php:936
+#: includes/template-functions.php:928
 msgid "Price: Low to High"
 msgstr ""
 
-#: includes/template-functions.php:937
+#: includes/template-functions.php:929
 msgid "Date: Newest First"
 msgstr ""
 
-#: includes/template-functions.php:938
+#: includes/template-functions.php:930
 msgid "Date: Oldest First"
 msgstr ""
 
-#: includes/template-functions.php:1002
+#: includes/template-functions.php:994
 msgid "About"
 msgstr ""
 
-#: includes/template-functions.php:1003
+#: includes/template-functions.php:995
 msgid "Bio"
 msgstr ""
 
-#: includes/template-functions.php:1004
+#: includes/template-functions.php:996
 msgid "Video"
 msgstr ""
 
@@ -1313,7 +1315,7 @@ msgstr ""
 msgid "What's New"
 msgstr ""
 
-#: menus/menu-help.php:36 menus/menu-welcome.php:294 menus/menu-welcome.php:645
+#: menus/menu-help.php:36 menus/menu-welcome.php:294 menus/menu-welcome.php:649
 msgid "Full Change Log"
 msgstr ""
 
@@ -1325,7 +1327,7 @@ msgstr ""
 msgid "Support the project"
 msgstr ""
 
-#: menus/menu-help.php:39 menus/menu-welcome.php:646
+#: menus/menu-help.php:39 menus/menu-welcome.php:650
 msgid "Visit Support"
 msgstr ""
 
@@ -1383,7 +1385,7 @@ msgstr ""
 msgid "The video will show you how to add a listing quickly and easily."
 msgstr ""
 
-#: menus/menu-help.php:112 menus/menu-welcome.php:718 widgets/widget-listing.php:271
+#: menus/menu-help.php:112 menus/menu-welcome.php:722 widgets/widget-listing.php:271
 msgid "Title"
 msgstr ""
 
@@ -1426,7 +1428,7 @@ msgstr ""
 msgid "Listing Image Gallery"
 msgstr ""
 
-#: menus/menu-help.php:134 menus/menu-welcome.php:739
+#: menus/menu-help.php:134 menus/menu-welcome.php:743
 msgid "Add a gallery of images to your listings with the WordPress Add Media button."
 msgstr ""
 
@@ -1436,7 +1438,7 @@ msgid ""
 "media upload box once the images are attached to the listing."
 msgstr ""
 
-#: menus/menu-help.php:147 menus/menu-welcome.php:757 meta-boxes/meta-boxes.php:108
+#: menus/menu-help.php:147 menus/menu-welcome.php:761 meta-boxes/meta-boxes.php:108
 #: post-types/post-type-business.php:86 post-types/post-type-commercial.php:84
 #: post-types/post-type-commercial_land.php:85 post-types/post-type-land.php:85
 #: post-types/post-type-property.php:85 post-types/post-type-rental.php:84
@@ -1444,26 +1446,26 @@ msgstr ""
 msgid "Listing Details"
 msgstr ""
 
-#: menus/menu-help.php:149 menus/menu-welcome.php:763 meta-boxes/meta-boxes.php:120
+#: menus/menu-help.php:149 menus/menu-welcome.php:767 meta-boxes/meta-boxes.php:120
 msgid "Heading"
 msgstr ""
 
-#: menus/menu-help.php:150 menus/menu-welcome.php:764
+#: menus/menu-help.php:150 menus/menu-welcome.php:768
 msgid "Enter the descriptive listing headline like \"Great Property with Views\"."
 msgstr ""
 
-#: menus/menu-help.php:152 menus/menu-welcome.php:766 meta-boxes/meta-boxes.php:148
+#: menus/menu-help.php:152 menus/menu-welcome.php:770 meta-boxes/meta-boxes.php:148
 #: post-types/post-types.php:77
 msgid "Second Listing Agent"
 msgstr ""
 
-#: menus/menu-help.php:153 menus/menu-welcome.php:767
+#: menus/menu-help.php:153 menus/menu-welcome.php:771
 msgid ""
 "If the listing has two real estate agents marketing it, enter their WordPress user "
 "name here. The primary agent is the post Author."
 msgstr ""
 
-#: menus/menu-help.php:155 menus/menu-welcome.php:769
+#: menus/menu-help.php:155 menus/menu-welcome.php:773
 msgid "Inspection Times"
 msgstr ""
 
@@ -1514,19 +1516,19 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: menus/menu-welcome.php:157 menus/menu-welcome.php:619 menus/menu-welcome.php:959
+#: menus/menu-welcome.php:157 menus/menu-welcome.php:623 menus/menu-welcome.php:963
 #, php-format
 msgid "Welcome to Easy Property Listings %s"
 msgstr ""
 
-#: menus/menu-welcome.php:158 menus/menu-welcome.php:620 menus/menu-welcome.php:960
+#: menus/menu-welcome.php:158 menus/menu-welcome.php:624 menus/menu-welcome.php:964
 #, php-format
 msgid ""
 "Thank you for updating to the latest version! Easy Property Listings %s is ready to "
 "make your real estate website faster, safer and better!"
 msgstr ""
 
-#: menus/menu-welcome.php:159 menus/menu-welcome.php:621 menus/menu-welcome.php:961
+#: menus/menu-welcome.php:159 menus/menu-welcome.php:625 menus/menu-welcome.php:965
 #, php-format
 msgid "Version %s"
 msgstr ""
@@ -1858,224 +1860,240 @@ msgid ""
 msgstr ""
 
 #: menus/menu-welcome.php:302
-msgid "Tweak: Updated translation and added missing sqm translation element."
+msgid "New: Listing Search widget now has style options for adjusting the width."
 msgstr ""
 
 #: menus/menu-welcome.php:303
-msgid "Tweak: Allowed for hundredths decimal in bathrooms field."
+msgid "Tweak: Updated translation and added missing sqm translation element."
 msgstr ""
 
 #: menus/menu-welcome.php:304
-msgid "Fix: Auction listing price set to no displays auction date correctly."
+msgid "Tweak: Allowed for hundredths decimal in bathrooms field."
+msgstr ""
+
+#: menus/menu-welcome.php:305
+msgid "Tweak: Floor plan button CSS."
+msgstr ""
+
+#: menus/menu-welcome.php:306
+msgid "Tweak: Address and price responsive CSS."
 msgstr ""
 
 #: menus/menu-welcome.php:307
-msgid "Version 2.1.6"
+msgid "Fix: Auction listing price set to no displays auction date correctly."
 msgstr ""
 
-#: menus/menu-welcome.php:310
-msgid "Fix: Fancy pagination paging works correctly when shortcodes used on home page."
+#: menus/menu-welcome.php:308
+msgid "Fix: Fix: Author position css class."
 msgstr ""
 
 #: menus/menu-welcome.php:311
+msgid "Version 2.1.6"
+msgstr ""
+
+#: menus/menu-welcome.php:314
+msgid "Fix: Fancy pagination paging works correctly when shortcodes used on home page."
+msgstr ""
+
+#: menus/menu-welcome.php:315
 msgid "Fix: Wrapped new pagination feature in esc_url to prevent vulnerability."
 msgstr ""
 
-#: menus/menu-welcome.php:312
+#: menus/menu-welcome.php:316
 msgid ""
 "Fix: Corrected sorting by price when using shortcodes. Note: Rental sorting works on "
 "post_type=\"rental\" in all shortcodes."
 msgstr ""
 
-#: menus/menu-welcome.php:313
+#: menus/menu-welcome.php:317
 msgid ""
 "Tweak: Added rental rate view for text entry of rental rates for REAXML compatibility."
 msgstr ""
 
-#: menus/menu-welcome.php:314
+#: menus/menu-welcome.php:318
 msgid ""
 "Tweak: Corrected admin display columns and edit listing pages for better display on "
 "mobile devices."
 msgstr ""
 
-#: menus/menu-welcome.php:317
+#: menus/menu-welcome.php:321
 msgid "Version 2.1.5"
 msgstr ""
 
-#: menus/menu-welcome.php:320
+#: menus/menu-welcome.php:324
 msgid ""
 "Tweak: Commercial listing: Ability to set commercial lease rate to a decimal value "
 "using the epl_price_number_format_commercial_lease filter."
 msgstr ""
 
-#: menus/menu-welcome.php:321
+#: menus/menu-welcome.php:325
 msgid "Tweak: Updated epl.pot translation file."
 msgstr ""
 
-#: menus/menu-welcome.php:322
+#: menus/menu-welcome.php:326
 msgid ""
 "Tweak: Removed horizontal line elements in the help section to match WordPress 4.2 "
 "admin page styles."
 msgstr ""
 
-#: menus/menu-welcome.php:323
+#: menus/menu-welcome.php:327
 msgid ""
 "Tweak: Rental Listing: Added epl_property_bond_position filter to adjust the position "
 "of the Bond/Deposit to appear either before or after the value."
 msgstr ""
 
-#: menus/menu-welcome.php:324
+#: menus/menu-welcome.php:328
 msgid "Tweak: Rental Listing: Removed CSS padding before bond value."
 msgstr ""
 
-#: menus/menu-welcome.php:325
+#: menus/menu-welcome.php:329
 msgid ""
 "Fix: Rental Listing: Adjusting the Bond/Deposit label will now show your custom label "
 "in the Rental Price box."
 msgstr ""
 
-#: menus/menu-welcome.php:326
+#: menus/menu-welcome.php:330
 msgid "Fix: Rural Listing: Undefined label_leased variable."
 msgstr ""
 
-#: menus/menu-welcome.php:327
+#: menus/menu-welcome.php:331
 msgid ""
 "Note: Confirmed Easy Property Listings is not vulnerable to recent WordPress exploit."
 msgstr ""
 
-#: menus/menu-welcome.php:328
+#: menus/menu-welcome.php:332
 msgid "New: Added setting to show/hide Listing Unique ID column when managing listings."
 msgstr ""
 
-#: menus/menu-welcome.php:331
+#: menus/menu-welcome.php:335
 msgid "Version 2.1.4"
 msgstr ""
 
-#: menus/menu-welcome.php:334
+#: menus/menu-welcome.php:338
 msgid "Tweak: Pagination optimised and no longer loads in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:335
+#: menus/menu-welcome.php:339
 msgid "Tweak: New filter epl_price_number_format added for decimal rental rates."
 msgstr ""
 
-#: menus/menu-welcome.php:336
+#: menus/menu-welcome.php:340
 msgid "Fix: Display custom bond label when viewing listings."
 msgstr ""
 
-#: menus/menu-welcome.php:337
+#: menus/menu-welcome.php:341
 msgid ""
 "Tweak: Added filter epl_floorplan_button_label_filter to adjust Floor Plan button "
 "label."
 msgstr ""
 
-#: menus/menu-welcome.php:340
+#: menus/menu-welcome.php:344
 msgid "Version 2.1.3"
 msgstr ""
 
-#: menus/menu-welcome.php:343
+#: menus/menu-welcome.php:347
 msgid ""
 "Fix: Author box upgraded to allow for custom tabs and better extension integration "
 "with author box and widget."
 msgstr ""
 
-#: menus/menu-welcome.php:344
+#: menus/menu-welcome.php:348
 msgid "Fix: Added additional epl-author-archive CSS class for author archive pages."
 msgstr ""
 
-#: menus/menu-welcome.php:345
+#: menus/menu-welcome.php:349
 msgid "Fix: Improved CSS classes for author box with better responsive support."
 msgstr ""
 
-#: menus/menu-welcome.php:346
+#: menus/menu-welcome.php:350
 msgid "Fix: Added additional filters for author contact information."
 msgstr ""
 
-#: menus/menu-welcome.php:347
+#: menus/menu-welcome.php:351
 msgid ""
 "Fix: Added secondary global author function for simpler integration for extensions "
 "like the Staff Directory."
 msgstr ""
 
-#: menus/menu-welcome.php:348
+#: menus/menu-welcome.php:352
 msgid "Fix: Changes to author tempaltes and restored author position variable."
 msgstr ""
 
-#: menus/menu-welcome.php:349
+#: menus/menu-welcome.php:353
 msgid "Fix: Further improved max and min graph values when in listing admin."
 msgstr ""
 
-#: menus/menu-welcome.php:352
+#: menus/menu-welcome.php:356
 msgid "Version 2.1.2"
 msgstr ""
 
-#: menus/menu-welcome.php:354
+#: menus/menu-welcome.php:358
 msgid "Fix: Improved Responsive CSS for grid style."
 msgstr ""
 
-#: menus/menu-welcome.php:355
+#: menus/menu-welcome.php:359
 msgid ""
 "Fix: Twenty Fifteen, Twenty Fourteen, Twenty Thirteen, Twenty Twelve CSS styles for "
 "better display."
 msgstr ""
 
-#: menus/menu-welcome.php:356
+#: menus/menu-welcome.php:360
 msgid "New: Added CSS class theme name output to archive and single templates."
 msgstr ""
 
-#: menus/menu-welcome.php:359
+#: menus/menu-welcome.php:363
 msgid "Version 2.1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:361
+#: menus/menu-welcome.php:365
 msgid ""
 "Fix: Max price defaults set for graph calculations when upgrading from pre 2.0 "
 "version."
 msgstr ""
 
-#: menus/menu-welcome.php:364
+#: menus/menu-welcome.php:368
 msgid "Version 2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:366
+#: menus/menu-welcome.php:370
 msgid "New: Fancy pagination option which can be enabled in settings."
 msgstr ""
 
-#: menus/menu-welcome.php:367
+#: menus/menu-welcome.php:371
 msgid "New: Coordinates now added to listing if not set prior."
 msgstr ""
 
-#: menus/menu-welcome.php:368
+#: menus/menu-welcome.php:372
 msgid "New: Ability to select larger listing image sizes in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:369
+#: menus/menu-welcome.php:373
 msgid "New: Added date picker for available date on rental listing."
 msgstr ""
 
-#: menus/menu-welcome.php:370
+#: menus/menu-welcome.php:374
 msgid "New: Added date picker for sold date."
 msgstr ""
 
-#: menus/menu-welcome.php:371
+#: menus/menu-welcome.php:375
 msgid ""
 "New: New function that combines all meta box options into one global function for "
 "admin pages."
 msgstr ""
 
-#: menus/menu-welcome.php:372
+#: menus/menu-welcome.php:376
 msgid "New: Display second agent name in admin listing lists."
 msgstr ""
 
-#: menus/menu-welcome.php:373
+#: menus/menu-welcome.php:377
 msgid "New: Additional admin option to filter by agent/author. "
 msgstr ""
 
-#: menus/menu-welcome.php:374
+#: menus/menu-welcome.php:378
 msgid "New: Shortcode [listing_location] to display listings by specific location."
 msgstr ""
 
-#: menus/menu-welcome.php:375
+#: menus/menu-welcome.php:379
 msgid ""
 "New: The following shortcodes can now be filtered by location taxonomy: [listing "
 "location=\"perth\"], [listing_open location=\"sydney\"], [listing_category location="
@@ -2083,485 +2101,485 @@ msgid ""
 "\"terrace\" location=\"new-york\"]"
 msgstr ""
 
-#: menus/menu-welcome.php:376
+#: menus/menu-welcome.php:380
 msgid ""
 "New: The following shortcodes can now be sorted by price, date and ordered by ASC and "
 "DESC [listing sortby=\"price\" sort_order=\"ASC\"]."
 msgstr ""
 
-#: menus/menu-welcome.php:377
+#: menus/menu-welcome.php:381
 msgid ""
 "New: Sorter added to shortcodes which can be enabled by adding tools_top=\"on\" to "
 "your shortcode options."
 msgstr ""
 
-#: menus/menu-welcome.php:378
+#: menus/menu-welcome.php:382
 msgid "New: Template added in table format for use in shortcodes template=\"table\"."
 msgstr ""
 
-#: menus/menu-welcome.php:379
+#: menus/menu-welcome.php:383
 msgid "New: Function to get all active post types."
 msgstr ""
 
-#: menus/menu-welcome.php:380
+#: menus/menu-welcome.php:384
 msgid "New: Ability to register additional custom post types."
 msgstr ""
 
-#: menus/menu-welcome.php:381
+#: menus/menu-welcome.php:385
 msgid "New: Extensions now have additional help text ability."
 msgstr ""
 
-#: menus/menu-welcome.php:382
+#: menus/menu-welcome.php:386
 msgid "New: All menus now use global function to render fields."
 msgstr ""
 
-#: menus/menu-welcome.php:383
+#: menus/menu-welcome.php:387
 msgid ""
 "New: Improved template output and added additional CSS wrappers for some theme and "
 "HTML5 themes."
 msgstr ""
 
-#: menus/menu-welcome.php:384
+#: menus/menu-welcome.php:388
 msgid "New: Commercial rental lease duration now selectable."
 msgstr ""
 
-#: menus/menu-welcome.php:385
+#: menus/menu-welcome.php:389
 msgid "New: Rooms field added to set the number of rooms that the listing has."
 msgstr ""
 
-#: menus/menu-welcome.php:386
+#: menus/menu-welcome.php:390
 msgid "New: Date listed field added to all listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:387
+#: menus/menu-welcome.php:391
 msgid "New: Year built field added to property, rental, rural listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:388
+#: menus/menu-welcome.php:392
 msgid "New: Media upload function for use in extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:389
+#: menus/menu-welcome.php:393
 msgid "New: Ability to customise Under Offer and Leased labels in settings."
 msgstr ""
 
-#: menus/menu-welcome.php:390
+#: menus/menu-welcome.php:394
 msgid ""
 "New: Lease type label loaded from dropdown select. So you can have NNN, P.A., Full "
 "Service, Gross Lease Rates, on commercial listing types. Also has a filter to enable "
 "customisation of the options."
 msgstr ""
 
-#: menus/menu-welcome.php:391
+#: menus/menu-welcome.php:395
 msgid "New: Disable links in the feature list."
 msgstr ""
 
-#: menus/menu-welcome.php:392
+#: menus/menu-welcome.php:396
 msgid "Fix: Text domain fixes on template files."
 msgstr ""
 
-#: menus/menu-welcome.php:393
+#: menus/menu-welcome.php:397
 msgid "Fix: Finnish translation file renamed."
 msgstr ""
 
-#: menus/menu-welcome.php:394
+#: menus/menu-welcome.php:398
 msgid "Fix: FeedSync date processor strptime function corrected."
 msgstr ""
 
-#: menus/menu-welcome.php:395
+#: menus/menu-welcome.php:399
 msgid ""
 "Fix: Bug in parking search field. Was only searching carports and not garages. Now "
 "searches both."
 msgstr ""
 
-#: menus/menu-welcome.php:396
+#: menus/menu-welcome.php:400
 msgid "Fix: New label now appears on listings not just with an inspection time saved."
 msgstr ""
 
-#: menus/menu-welcome.php:397
+#: menus/menu-welcome.php:401
 msgid "Tweak: Optimised loading of admin scripts and styles to pages where required."
 msgstr ""
 
-#: menus/menu-welcome.php:398
+#: menus/menu-welcome.php:402
 msgid ""
 "Tweak: Added version to CSS and JS so new versions are automatically used when plugin "
 "is updated."
 msgstr ""
 
-#: menus/menu-welcome.php:399
+#: menus/menu-welcome.php:403
 msgid "Tweak: Tidy up of admin CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:400
+#: menus/menu-welcome.php:404
 msgid "Tweak: Video in author box now responsive."
 msgstr ""
 
-#: menus/menu-welcome.php:401
+#: menus/menu-welcome.php:405
 msgid ""
 "Tweak: Increased characters possible in address block fields from 40 to 80 characters "
 "and heading block to 200."
 msgstr ""
 
-#: menus/menu-welcome.php:402
+#: menus/menu-welcome.php:406
 msgid "Tweak: Coordinates now correctly being used to generate map."
 msgstr ""
 
-#: menus/menu-welcome.php:403
+#: menus/menu-welcome.php:407
 msgid "Tweak: Inspection times improved style in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:404
+#: menus/menu-welcome.php:408
 msgid "Tweak: Commercial rental rate now accepts decimal numbers."
 msgstr ""
 
-#: menus/menu-welcome.php:405
+#: menus/menu-welcome.php:409
 msgid "Tweak: Improved google map output."
 msgstr ""
 
-#: menus/menu-welcome.php:406
+#: menus/menu-welcome.php:410
 msgid "Tweak: Improved default settings on upgrade, install and multisite."
 msgstr ""
 
-#: menus/menu-welcome.php:407
+#: menus/menu-welcome.php:411
 msgid "Tweak: Scripts improve site speed."
 msgstr ""
 
-#: menus/menu-welcome.php:408
+#: menus/menu-welcome.php:412
 msgid "Tweak: Dashboard widget improved query."
 msgstr ""
 
-#: menus/menu-welcome.php:409
+#: menus/menu-welcome.php:413
 msgid "Tweak: Front end CSS tweaks for better responsiveness."
 msgstr ""
 
-#: menus/menu-welcome.php:412
+#: menus/menu-welcome.php:416
 msgid "Version 2.0.3"
 msgstr ""
 
-#: menus/menu-welcome.php:414
+#: menus/menu-welcome.php:418
 msgid "Fix: Manually entered inspection capitalization fixed pM to PM."
 msgstr ""
 
-#: menus/menu-welcome.php:415
+#: menus/menu-welcome.php:419
 msgid "New: French translation (Thanks to Thomas Grimaud)"
 msgstr ""
 
-#: menus/menu-welcome.php:416
+#: menus/menu-welcome.php:420
 msgid "New: Finnish translation (Thanks to Turo)"
 msgstr ""
 
-#: menus/menu-welcome.php:419
+#: menus/menu-welcome.php:423
 msgid "Version 2.0.2"
 msgstr ""
 
-#: menus/menu-welcome.php:421
+#: menus/menu-welcome.php:425
 msgid ""
 "Fix: Added fall-back diff() function which is not present in PHP 5.2 or earlier used "
 "with the New label."
 msgstr ""
 
-#: menus/menu-welcome.php:422
+#: menus/menu-welcome.php:426
 msgid ""
 "Fix: Some Labels in settings were not saving correctly particularly the search widget "
 "labels."
 msgstr ""
 
-#: menus/menu-welcome.php:423
+#: menus/menu-welcome.php:427
 msgid "Fix: Restored missing author profile contact form tab on author box."
 msgstr ""
 
-#: menus/menu-welcome.php:424
+#: menus/menu-welcome.php:428
 msgid "Tweak: Added CSS version to admin CSS and front end CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:427
+#: menus/menu-welcome.php:431
 msgid "Version 2.0.1"
 msgstr ""
 
-#: menus/menu-welcome.php:429
+#: menus/menu-welcome.php:433
 msgid ""
 "Fix: Attempted Twenty 15 CSS Fix but causes issues with other themes. Manual fix: "
 "Copy CSS from style-front.css to correct, margins and grid/sorter."
 msgstr ""
 
-#: menus/menu-welcome.php:430
+#: menus/menu-welcome.php:434
 msgid ""
 "Fix: Restored Display of Inspection Label for properties with scheduled inspection "
 "times."
 msgstr ""
 
-#: menus/menu-welcome.php:431
+#: menus/menu-welcome.php:435
 msgid "Fix: Search Widget security fix and performance improvements."
 msgstr ""
 
-#: menus/menu-welcome.php:434
+#: menus/menu-welcome.php:438
 msgid "Version 2.0"
 msgstr ""
 
-#: menus/menu-welcome.php:436
+#: menus/menu-welcome.php:440
 msgid "New: Extension validator."
 msgstr ""
 
-#: menus/menu-welcome.php:437
+#: menus/menu-welcome.php:441
 msgid "New: Depreciated listing-meta.php into compatibility folder."
 msgstr ""
 
-#: menus/menu-welcome.php:438
+#: menus/menu-welcome.php:442
 msgid "New: Depreciated author-meta.php into compatibility folder."
 msgstr ""
 
-#: menus/menu-welcome.php:439
+#: menus/menu-welcome.php:443
 msgid "New: Global variables: $property, $epl_author and $epl_settings."
 msgstr ""
 
-#: menus/menu-welcome.php:440
+#: menus/menu-welcome.php:444
 msgid "New: Added filters for fields and groups in /lib/meta-boxes.php"
 msgstr ""
 
-#: menus/menu-welcome.php:441
+#: menus/menu-welcome.php:445
 msgid ""
 "New: Property custom meta re-written into class. This was the big change to 2.0 where "
 "we completely re-wrote the output of the meta values which are now accessible using "
 "global $property variable and easy template actions."
 msgstr ""
 
-#: menus/menu-welcome.php:442
+#: menus/menu-welcome.php:446
 msgid ""
 "New: Property meta can now can be output using new actions for easy and quick custom "
 "template creation."
 msgstr ""
 
-#: menus/menu-welcome.php:443
+#: menus/menu-welcome.php:447
 msgid "New: Reconstructed templates for single, archive & author pages"
 msgstr ""
 
-#: menus/menu-welcome.php:444
+#: menus/menu-welcome.php:448
 msgid "Tweak: Removed unused price script"
 msgstr ""
 
-#: menus/menu-welcome.php:445
+#: menus/menu-welcome.php:449
 msgid "Fix: Fixed warning related to static instance in strict standard modes"
 msgstr ""
 
-#: menus/menu-welcome.php:446
+#: menus/menu-welcome.php:450
 msgid "New: API for extensions now support WordPress editor with validation."
 msgstr ""
 
-#: menus/menu-welcome.php:447
+#: menus/menu-welcome.php:451
 msgid ""
 "New: jQuery date time picker formatting added to improve support for auction and sold "
 "listing, support for 30+ languages support."
 msgstr ""
 
-#: menus/menu-welcome.php:448
+#: menus/menu-welcome.php:452
 msgid ""
 "New: Inspection time auto-formats REAXML date eg [13-Dec-2014 11:00am to 11:45am] and "
 "will no longer show past inspection times."
 msgstr ""
 
-#: menus/menu-welcome.php:449
+#: menus/menu-welcome.php:453
 msgid "New: Inspection time support multiple dates written one per line."
 msgstr ""
 
-#: menus/menu-welcome.php:450
+#: menus/menu-welcome.php:454
 msgid "Tweak: CSS improved with better commenting and size reduction."
 msgstr ""
 
-#: menus/menu-welcome.php:451
+#: menus/menu-welcome.php:455
 msgid ""
 "New: Dashboard widget now lists all listing status so at a glance you can see your "
 "property stock."
 msgstr ""
 
-#: menus/menu-welcome.php:452
+#: menus/menu-welcome.php:456
 msgid ""
 "New: Display: To enable grid, list and sorter your custom archive-listing.php "
 "template requires the new action hook epl_template_before_property_loop before the "
 "WordPress loop."
 msgstr ""
 
-#: menus/menu-welcome.php:453
+#: menus/menu-welcome.php:457
 msgid ""
 "New: Display: Utility hook action hook added epl_template_after_property_loop for "
 "future updates."
 msgstr ""
 
-#: menus/menu-welcome.php:454
+#: menus/menu-welcome.php:458
 msgid "New: Display: List and grid view with optional masonry effect."
 msgstr ""
 
-#: menus/menu-welcome.php:455
+#: menus/menu-welcome.php:459
 msgid "New: Display: Sorter added for price high/low and date newest/oldest."
 msgstr ""
 
-#: menus/menu-welcome.php:456
+#: menus/menu-welcome.php:460
 msgid "New: Auction Date formats nicely. EG [Auction Saturday 28th December at 2:00pm]."
 msgstr ""
 
-#: menus/menu-welcome.php:457
+#: menus/menu-welcome.php:461
 msgid ""
 "New: Tabbed extensions page support in admin for advanced extensions like Listing "
 "Alerts."
 msgstr ""
 
-#: menus/menu-welcome.php:458
+#: menus/menu-welcome.php:462
 msgid "New: Multiple author support in Author Box."
 msgstr ""
 
-#: menus/menu-welcome.php:459
+#: menus/menu-welcome.php:463
 msgid ""
 "New: Search Widget - Supports multiple listing types, hold Ctrl to enable tabbed "
 "front end display."
 msgstr ""
 
-#: menus/menu-welcome.php:460
+#: menus/menu-welcome.php:464
 msgid ""
 "New: Search Widget - Labels are configurable from the Display settings allowing you "
 "to set for example: Property to Buy and Rental to Rent and use a single widget to "
 "search multiple types."
 msgstr ""
 
-#: menus/menu-welcome.php:461
+#: menus/menu-welcome.php:465
 msgid ""
 "New: Search Widget and shortcode supports search by property ID, post Title, Land "
 "Area and Building Area."
 msgstr ""
 
-#: menus/menu-welcome.php:462
+#: menus/menu-welcome.php:466
 msgid ""
 "New: Search Widget - removed extra fields from land, added labels for each property "
 "type to be shown as tab heading in search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:463
+#: menus/menu-welcome.php:467
 msgid ""
 "Fix: Search Widget - Optimized total queries due to search widget from 1500 + to ~40"
 msgstr ""
 
-#: menus/menu-welcome.php:464
+#: menus/menu-welcome.php:468
 msgid "New: Author variables accessible using new CLASS."
 msgstr ""
 
-#: menus/menu-welcome.php:465
+#: menus/menu-welcome.php:469
 msgid "New: Search short code supports array of property types."
 msgstr ""
 
-#: menus/menu-welcome.php:466
+#: menus/menu-welcome.php:470
 msgid ""
 "New: REAXML date format function to format date correctly when using WP All Import "
 "Pro. Usage [epl_feedsync_format_date({./@modTime})]."
 msgstr ""
 
-#: menus/menu-welcome.php:467
+#: menus/menu-welcome.php:471
 msgid ""
 "New: REAXML Unit and lot formatting function for usage in the title when using WP All "
 "Import Pro. Usage [epl_feedsync_filter_sub_number({address[1]/subNumber[1]})]."
 msgstr ""
 
-#: menus/menu-welcome.php:468
+#: menus/menu-welcome.php:472
 msgid ""
 "New: Global $epl_settings settings variable adds new default values on plugin update."
 msgstr ""
 
-#: menus/menu-welcome.php:469
+#: menus/menu-welcome.php:473
 msgid "New: Display: Added customisable label for rental Bond/Deposit."
 msgstr ""
 
-#: menus/menu-welcome.php:470
+#: menus/menu-welcome.php:474
 msgid ""
 "New: Template functions completely re-written and can now be output using actions."
 msgstr ""
 
-#: menus/menu-welcome.php:471
+#: menus/menu-welcome.php:475
 msgid ""
 "New: Added NEW sticker with customisable label and ability to set how long a listing "
 "displays the new label."
 msgstr ""
 
-#: menus/menu-welcome.php:472
+#: menus/menu-welcome.php:476
 msgid "Tweak: Compatibility fixes"
 msgstr ""
 
-#: menus/menu-welcome.php:473
+#: menus/menu-welcome.php:477
 msgid "New: Bar Graph API added."
 msgstr ""
 
-#: menus/menu-welcome.php:474
+#: menus/menu-welcome.php:478
 msgid ""
 "New: Graph in admin allows you to set the max bar graph value. Default are (2,000,000 "
 "sale) and (2,000 rental)."
 msgstr ""
 
-#: menus/menu-welcome.php:475
+#: menus/menu-welcome.php:479
 msgid "New: Graph visually displays price and status."
 msgstr ""
 
-#: menus/menu-welcome.php:476
+#: menus/menu-welcome.php:480
 msgid ""
 "New: Price graph now appears in admin pages quickly highlighting price and status "
 "visually."
 msgstr ""
 
-#: menus/menu-welcome.php:477
+#: menus/menu-welcome.php:481
 msgid "New: Meta Fields: Support for unit number, lot number (land)."
 msgstr ""
 
-#: menus/menu-welcome.php:478
+#: menus/menu-welcome.php:482
 msgid "New: South African ZAR currency support."
 msgstr ""
 
-#: menus/menu-welcome.php:479
+#: menus/menu-welcome.php:483
 msgid "Fix: Corrected Commercial Features ID Spelling"
 msgstr ""
 
-#: menus/menu-welcome.php:480
+#: menus/menu-welcome.php:484
 msgid ""
 "Tweak: YouTube video src to id function is replaced with better method which handles "
 "multiple YouTube video formats including shortened & embedded format"
 msgstr ""
 
-#: menus/menu-welcome.php:481
+#: menus/menu-welcome.php:485
 msgid "New: Adding Sold Date processing"
 msgstr ""
 
-#: menus/menu-welcome.php:482
+#: menus/menu-welcome.php:486
 msgid "Tweak: Updated shortcode templates"
 msgstr ""
 
-#: menus/menu-welcome.php:483
+#: menus/menu-welcome.php:487
 msgid "Tweak: Global $epl_author."
 msgstr ""
 
-#: menus/menu-welcome.php:484
+#: menus/menu-welcome.php:488
 msgid "Tweak: Fixed content/ into EPL_PATH_TEMPLATES_CONTENT"
 msgstr ""
 
-#: menus/menu-welcome.php:485
+#: menus/menu-welcome.php:489
 msgid "New: Support for older extensions added"
 msgstr ""
 
-#: menus/menu-welcome.php:486
+#: menus/menu-welcome.php:490
 msgid "New: Extension offers in menus general tab"
 msgstr ""
 
-#: menus/menu-welcome.php:487
+#: menus/menu-welcome.php:491
 msgid ""
 "Tweak: Renamed user profile options section to [Easy Property Listings: Author Box "
 "Profile]."
 msgstr ""
 
-#: menus/menu-welcome.php:488
+#: menus/menu-welcome.php:492
 msgid "Tweak: Added better Bond/Deposit for rentals labels."
 msgstr ""
 
-#: menus/menu-welcome.php:489
+#: menus/menu-welcome.php:493
 msgid ""
 "Fix: Deprecated author-meta.php in compatibility folder, class-author-meta.php has "
 "been created which will be used in place of author-meta.php & its variables in all "
 "author templates"
 msgstr ""
 
-#: menus/menu-welcome.php:490
+#: menus/menu-welcome.php:494
 msgid ""
 "New: Added template functions for author meta class, modified templates lib/templates/"
 "content/content-author-box-simple-card.php lib/templates/content/content-author-box-"
@@ -2569,545 +2587,545 @@ msgid ""
 "functions based on author meta class instead of variables from author-meta.php"
 msgstr ""
 
-#: menus/menu-welcome.php:491
+#: menus/menu-welcome.php:495
 msgid ""
 "New: author-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available using $epl_author variable."
 msgstr ""
 
-#: menus/menu-welcome.php:492
+#: menus/menu-welcome.php:496
 msgid ""
 "Tweak: listing-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available with $property variable."
 msgstr ""
 
-#: menus/menu-welcome.php:493
+#: menus/menu-welcome.php:497
 msgid ""
 "Tweak: Added Listing not Found to default templates when search performed with no "
 "results."
 msgstr ""
 
-#: menus/menu-welcome.php:494
+#: menus/menu-welcome.php:498
 msgid "Tweak: Improved Google maps address output for addresses containing # and /."
 msgstr ""
 
-#: menus/menu-welcome.php:495
+#: menus/menu-welcome.php:499
 msgid ""
 "Fix: Listing Pages now have better responsive support for small screen devices like "
 "iPhone."
 msgstr ""
 
-#: menus/menu-welcome.php:496
+#: menus/menu-welcome.php:500
 msgid ""
 "Fix: Default templates for Genesis and TwentyTwelve now show Listing Not Found when a "
 "search result returns empty."
 msgstr ""
 
-#: menus/menu-welcome.php:497
+#: menus/menu-welcome.php:501
 msgid "Fix: Purged translations in epl.pot file."
 msgstr ""
 
-#: menus/menu-welcome.php:498
+#: menus/menu-welcome.php:502
 msgid "Fix: Search Widget and short code drastically reduces database queries."
 msgstr ""
 
-#: menus/menu-welcome.php:499
+#: menus/menu-welcome.php:503
 msgid ""
 "New: Templates are now able to be saved in active theme folder /easypropertylistings "
 "and edited. Plugin will use these first and fall back to plugin if not located in "
 "theme folder."
 msgstr ""
 
-#: menus/menu-welcome.php:500
+#: menus/menu-welcome.php:504
 msgid "Fix: Extensions Notification and checker updated"
 msgstr ""
 
-#: menus/menu-welcome.php:501
+#: menus/menu-welcome.php:505
 msgid "New: updated author templates to use new author meta class"
 msgstr ""
 
-#: menus/menu-welcome.php:502
+#: menus/menu-welcome.php:506
 msgid ""
 "Fix: Added prefix to CSS tab-content class. Now epl-tab-content for compatibility."
 msgstr ""
 
-#: menus/menu-welcome.php:503
+#: menus/menu-welcome.php:507
 msgid "New: Update user.php"
 msgstr ""
 
-#: menus/menu-welcome.php:504
+#: menus/menu-welcome.php:508
 msgid "Tweak: Improved internal documentation and updated screens."
 msgstr ""
 
-#: menus/menu-welcome.php:505
+#: menus/menu-welcome.php:509
 msgid "Tweak: Improved descriptions on author pages."
 msgstr ""
 
-#: menus/menu-welcome.php:506
+#: menus/menu-welcome.php:510
 msgid "Tweak: Better permalink flushing on activation, deactivation and install."
 msgstr ""
 
-#: menus/menu-welcome.php:507
+#: menus/menu-welcome.php:511
 msgid "Tweak: Extensive changes to admin descriptions and labels."
 msgstr ""
 
-#: menus/menu-welcome.php:508
+#: menus/menu-welcome.php:512
 msgid "Tweak: Optimising the php loading of files and scripts."
 msgstr ""
 
-#: menus/menu-welcome.php:509
+#: menus/menu-welcome.php:513
 msgid "New: Define EPL_RUNNING added for extensions to check if plugin is active."
 msgstr ""
 
-#: menus/menu-welcome.php:510
+#: menus/menu-welcome.php:514
 msgid "New: New options added to setting array when plugin is updated."
 msgstr ""
 
-#: menus/menu-welcome.php:511
+#: menus/menu-welcome.php:515
 msgid ""
 "New: Old functions and files moved to plug-in /compatibility folder to ensure old "
 "code still works."
 msgstr ""
 
-#: menus/menu-welcome.php:512
+#: menus/menu-welcome.php:516
 msgid "New: Meta Location Label."
 msgstr ""
 
-#: menus/menu-welcome.php:513
+#: menus/menu-welcome.php:517
 msgid "New: Service banners on settings page."
 msgstr ""
 
-#: menus/menu-welcome.php:514
+#: menus/menu-welcome.php:518
 msgid "New: Saving version number so when updating new settings are added."
 msgstr ""
 
-#: menus/menu-welcome.php:515
+#: menus/menu-welcome.php:519
 msgid ""
 "New: iCal functionality for REAXML formatted inspection dates. Further improvements "
 "coming for manual date entry. "
 msgstr ""
 
-#: menus/menu-welcome.php:516
+#: menus/menu-welcome.php:520
 msgid "New: Extensions options pages now with tabs for easier usage."
 msgstr ""
 
-#: menus/menu-welcome.php:517
+#: menus/menu-welcome.php:521
 msgid "New: Added ID classes to admin pages and meta fields."
 msgstr ""
 
-#: menus/menu-welcome.php:518
+#: menus/menu-welcome.php:522
 msgid "New: Filters to adjust land and building sizes from number to select fields."
 msgstr ""
 
-#: menus/menu-welcome.php:519
+#: menus/menu-welcome.php:523
 msgid ""
 "Tweak: Moved old extensions options page to compatibility folder so older extensions "
 "still work as expected."
 msgstr ""
 
-#: menus/menu-welcome.php:520
+#: menus/menu-welcome.php:524
 msgid ""
 "New: Search Widget - Added filter for land min & max fields in listing search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:521
+#: menus/menu-welcome.php:525
 msgid ""
 "New: Search Widget - Added filter for building min & max fields in listing search "
 "widget"
 msgstr ""
 
-#: menus/menu-welcome.php:522
+#: menus/menu-welcome.php:526
 msgid "Fix: For session start effecting certain themes"
 msgstr ""
 
-#: menus/menu-welcome.php:523
+#: menus/menu-welcome.php:527
 msgid "New: Land sizes now allow up to 5 decimal places"
 msgstr ""
 
-#: menus/menu-welcome.php:524
+#: menus/menu-welcome.php:528
 msgid "New: Search Widget - Custom submit label"
 msgstr ""
 
-#: menus/menu-welcome.php:525
+#: menus/menu-welcome.php:529
 msgid "New: Search Widget - Can search by title in property ID / Address field"
 msgstr ""
 
-#: menus/menu-welcome.php:526
+#: menus/menu-welcome.php:530
 msgid "New: Added Russian Translation"
 msgstr ""
 
-#: menus/menu-welcome.php:529
+#: menus/menu-welcome.php:533
 msgid "Version 1.2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:531
+#: menus/menu-welcome.php:535
 msgid "Fix: Search Widget not working on page 2 of archive page in some instances"
 msgstr ""
 
-#: menus/menu-welcome.php:532
+#: menus/menu-welcome.php:536
 msgid ""
 "Fix: Property feature list Toilet and New Construction now display in list when ticked"
 msgstr ""
 
-#: menus/menu-welcome.php:533
+#: menus/menu-welcome.php:537
 msgid "Fix: EPL - Listing widget was not displaying featured listings"
 msgstr ""
 
-#: menus/menu-welcome.php:534
+#: menus/menu-welcome.php:538
 msgid ""
 "Fix: Allowed to filter by commercial_listing_type in [listing_category] shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:535
+#: menus/menu-welcome.php:539
 msgid "Fix: Updated templates to display Search Results when performing search"
 msgstr ""
 
-#: menus/menu-welcome.php:536
+#: menus/menu-welcome.php:540
 msgid "Fix: No longer show Bond when viewing rental list in admin"
 msgstr ""
 
-#: menus/menu-welcome.php:537
+#: menus/menu-welcome.php:541
 msgid "Fix: Open for inspection sticker now appears on rental properties"
 msgstr ""
 
-#: menus/menu-welcome.php:538
+#: menus/menu-welcome.php:542
 msgid "New: Added initial Dutch translation."
 msgstr ""
 
-#: menus/menu-welcome.php:541
+#: menus/menu-welcome.php:545
 msgid "Version 1.2"
 msgstr ""
 
-#: menus/menu-welcome.php:543
+#: menus/menu-welcome.php:547
 msgid "New: Plug in Activation process flushes permalinks"
 msgstr ""
 
-#: menus/menu-welcome.php:544
+#: menus/menu-welcome.php:548
 msgid "New: Plug in deactivation flushes permalinks"
 msgstr ""
 
-#: menus/menu-welcome.php:545
+#: menus/menu-welcome.php:549
 msgid "New: Shortcode [listing_search]"
 msgstr ""
 
-#: menus/menu-welcome.php:546
+#: menus/menu-welcome.php:550
 msgid "New: Shortcode [listing_feature]"
 msgstr ""
 
-#: menus/menu-welcome.php:547
+#: menus/menu-welcome.php:551
 msgid ""
 "New: Shortcode [listing_open] replaces [home_open] shortcode. Retained [home_open] "
 "for backward compatibility, however adjust your site. "
 msgstr ""
 
-#: menus/menu-welcome.php:548
+#: menus/menu-welcome.php:552
 msgid ""
 "New: Listing shortcodes allow for default template display if registered by adding "
 "template=\"slim\" to the shortcode."
 msgstr ""
 
-#: menus/menu-welcome.php:549
+#: menus/menu-welcome.php:553
 msgid "New: Translation support now correctly loads text domain epl"
 msgstr ""
 
-#: menus/menu-welcome.php:550
+#: menus/menu-welcome.php:554
 msgid "New: Added translation tags to all test elements for better translation support"
 msgstr ""
 
-#: menus/menu-welcome.php:551
+#: menus/menu-welcome.php:555
 msgid "New: Updated source epl.pot translation file for translations"
 msgstr ""
 
-#: menus/menu-welcome.php:552
+#: menus/menu-welcome.php:556
 msgid "New: Added very rough Italian translation"
 msgstr ""
 
-#: menus/menu-welcome.php:553
+#: menus/menu-welcome.php:557
 msgid ""
 "New: Wrapped Featured image in action to allow for easy removal and/or replacement"
 msgstr ""
 
-#: menus/menu-welcome.php:554
+#: menus/menu-welcome.php:558
 msgid "Fix: Undefined errors when debug is active"
 msgstr ""
 
-#: menus/menu-welcome.php:555
+#: menus/menu-welcome.php:559
 msgid "New: Added new CSS classes to widgets for consistent usage"
 msgstr ""
 
-#: menus/menu-welcome.php:556
+#: menus/menu-welcome.php:560
 msgid "Tweak: Admin CSS tweaks to define sections in admin"
 msgstr ""
 
-#: menus/menu-welcome.php:557
+#: menus/menu-welcome.php:561
 msgid "Fix: CSS for TwentyThirteen style CSS using .sidebar container"
 msgstr ""
 
-#: menus/menu-welcome.php:558
+#: menus/menu-welcome.php:562
 msgid "Fix: CSS for responsive shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:559
+#: menus/menu-welcome.php:563
 msgid ""
 "New: Added options to hide/ show various options to EPL - Listing widget: Property "
 "Headline, Excerpt, Suburb/Location Label, Street Address, Price, Read More Button"
 msgstr ""
 
-#: menus/menu-welcome.php:560
+#: menus/menu-welcome.php:564
 msgid "New: Added customisable \"Read More\" label to EPL - Listing widget"
 msgstr ""
 
-#: menus/menu-welcome.php:561
+#: menus/menu-welcome.php:565
 msgid "New: Added excerpt to EPL - Listing widget"
 msgstr ""
 
-#: menus/menu-welcome.php:562
+#: menus/menu-welcome.php:566
 msgid "New: Added options to remove search options from EPL - Listing Search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:563
+#: menus/menu-welcome.php:567
 msgid "New: Added consistent CSS classes to shortcodes for responsive shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:564
+#: menus/menu-welcome.php:568
 msgid ""
 "New: Date processing function for use with WP All Import when importing REAXML files. "
 "Some imports set the current date instead of the date from the REAXML file. Usage in "
 "WP All Import Post Date is: [epl_feedsync_format_date({./@modTime})]"
 msgstr ""
 
-#: menus/menu-welcome.php:565
+#: menus/menu-welcome.php:569
 msgid ""
 "Tweak: Added additional CSS classes to admin menu pages to extensions can be better "
 "distinguished when installed and activated"
 msgstr ""
 
-#: menus/menu-welcome.php:566
+#: menus/menu-welcome.php:570
 msgid "Fix: Registering custom template actions now works correctly"
 msgstr ""
 
-#: menus/menu-welcome.php:567
+#: menus/menu-welcome.php:571
 msgid "New: Added additional CSS classes to template files"
 msgstr ""
 
-#: menus/menu-welcome.php:568
+#: menus/menu-welcome.php:572
 msgid ""
 "Fix: Changed property not found wording when using search widget and listing not "
 "found. "
 msgstr ""
 
-#: menus/menu-welcome.php:569
+#: menus/menu-welcome.php:573
 msgid "Tweak: Added defaults to widgets to prevent errors when debug is on"
 msgstr ""
 
-#: menus/menu-welcome.php:570
+#: menus/menu-welcome.php:574
 msgid "New: Added WordPress editor support in admin for use with extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:571
+#: menus/menu-welcome.php:575
 msgid "New: Added textarea support in admin for use with extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:572
+#: menus/menu-welcome.php:576
 msgid ""
 "New: Filters added for all select options on add listing pages which allows for full "
 "customisation through simple function"
 msgstr ""
 
-#: menus/menu-welcome.php:573
+#: menus/menu-welcome.php:577
 msgid "New: Added rent period, Day, Daily, Month, Monthly to rental listing types"
 msgstr ""
 
-#: menus/menu-welcome.php:574
+#: menus/menu-welcome.php:578
 msgid "New: Added property_office_id meta field"
 msgstr ""
 
-#: menus/menu-welcome.php:575
+#: menus/menu-welcome.php:579
 msgid "New: Added property_address_country meta field"
 msgstr ""
 
-#: menus/menu-welcome.php:576
+#: menus/menu-welcome.php:580
 msgid "Tweak: Allowed for decimal in bathrooms to allow for 1/2 baths eg 1.5"
 msgstr ""
 
-#: menus/menu-welcome.php:577
+#: menus/menu-welcome.php:581
 msgid ""
 "New: Added mini map to listing edit screen. Will display mini map in address block "
 "when pressing green coordinates button."
 msgstr ""
 
-#: menus/menu-welcome.php:578
+#: menus/menu-welcome.php:582
 msgid ""
 "Fix: Updated admin columns for commercial_land listing type to match other listing "
 "type"
 msgstr ""
 
-#: menus/menu-welcome.php:579
+#: menus/menu-welcome.php:583
 msgid "Fix: Swapped bedrooms/bathroom label on hover"
 msgstr ""
 
-#: menus/menu-welcome.php:580
+#: menus/menu-welcome.php:584
 msgid ""
 "New: Added filter epl_listing_meta_boxes which allows additional meta boxes to be "
 "added through filter"
 msgstr ""
 
-#: menus/menu-welcome.php:583
+#: menus/menu-welcome.php:587
 msgid "Version 1.1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:585
+#: menus/menu-welcome.php:589
 msgid ""
 "New: Internationalisation support to enable customizing of post types: slug, archive, "
 "rewrite, labels, listing categories for meta_types."
 msgstr ""
 
-#: menus/menu-welcome.php:586
+#: menus/menu-welcome.php:590
 msgid ""
 "New: Created filters for listing meta select fields: property_category, "
 "property_rural_category, property_commercial_category, property_land_category."
 msgstr ""
 
-#: menus/menu-welcome.php:587
+#: menus/menu-welcome.php:591
 msgid ""
 "New: Created filters for each of the seven custom post types: labels, supports, slug, "
 "archive, rewrite, seven custom post types."
 msgstr ""
 
-#: menus/menu-welcome.php:588
+#: menus/menu-welcome.php:592
 msgid ""
 "New: Shortcode [listing_category] This shortcode allows for you to output a list of "
 "listings by type and filter them by any available meta key and value."
 msgstr ""
 
-#: menus/menu-welcome.php:589
+#: menus/menu-welcome.php:593
 msgid "Tweak: Updated search widget for filtered property_categories."
 msgstr ""
 
-#: menus/menu-welcome.php:590
+#: menus/menu-welcome.php:594
 msgid "Fix: Listing categories were showing key, now showing value."
 msgstr ""
 
-#: menus/menu-welcome.php:591
+#: menus/menu-welcome.php:595
 msgid ""
 "Fix: Settings were not showing up after saving, second refresh required setting "
 "variable to reload."
 msgstr ""
 
-#: menus/menu-welcome.php:594
+#: menus/menu-welcome.php:598
 msgid "Version 1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:596
+#: menus/menu-welcome.php:600
 msgid "First official release!"
 msgstr ""
 
-#: menus/menu-welcome.php:602
+#: menus/menu-welcome.php:606
 msgid "Go to Easy Property Listings Settings"
 msgstr ""
 
-#: menus/menu-welcome.php:626
+#: menus/menu-welcome.php:630
 msgid "Real Estate Tools for WordPress"
 msgstr ""
 
-#: menus/menu-welcome.php:634
+#: menus/menu-welcome.php:638
 msgid "Quick Start Guide"
 msgstr ""
 
-#: menus/menu-welcome.php:636
+#: menus/menu-welcome.php:640
 msgid ""
 "Use the tips below to get started using Easy Property Listings. You will be up and "
 "running in no time!"
 msgstr ""
 
-#: menus/menu-welcome.php:640
+#: menus/menu-welcome.php:644
 msgid "Activate the listing types you need & configure the plugin general settings"
 msgstr ""
 
-#: menus/menu-welcome.php:641 menus/menu-welcome.php:683
+#: menus/menu-welcome.php:645 menus/menu-welcome.php:687
 msgid "Create a blank page for each activated listing type"
 msgstr ""
 
-#: menus/menu-welcome.php:642
+#: menus/menu-welcome.php:646
 msgid "Publish your first listing for testing your theme setup"
 msgstr ""
 
-#: menus/menu-welcome.php:644
+#: menus/menu-welcome.php:648
 msgid "Setup your theme to work with the plugin"
 msgstr ""
 
-#: menus/menu-welcome.php:653
+#: menus/menu-welcome.php:657
 msgid "Activate the listing types you need"
 msgstr ""
 
-#: menus/menu-welcome.php:659
+#: menus/menu-welcome.php:663
 msgid ""
 "Visit the general settings page and enable the listing types you need. Once you have "
 "pressed save visit the Permalinks page to re-fresh your sites permalinks."
 msgstr ""
 
-#: menus/menu-welcome.php:661
+#: menus/menu-welcome.php:665
 msgid ""
 "Instead of classifying everything as a property, Easy Property Listings allows you to "
 "separate the different listing types which is better for SEO and RSS feeds."
 msgstr ""
 
-#: menus/menu-welcome.php:663
+#: menus/menu-welcome.php:667
 msgid "Supported Listing Types"
 msgstr ""
 
-#: menus/menu-welcome.php:688
+#: menus/menu-welcome.php:692
 msgid ""
 "Doing this allows you to add \"Property\", \"Land\" and \"Rental\" pages to your "
 "WordPress menu. Add a new page for each listing type you activated."
 msgstr ""
 
-#: menus/menu-welcome.php:690
+#: menus/menu-welcome.php:694
 msgid ""
 "For example, lets say you have activated: Property, Rental and Land. Create three "
 "pages, one called \"Property\", another \"Land\" and the third \"Rental\" these will "
 "be the custom post type slugs/permalinks eg: property, rental and land."
 msgstr ""
 
-#: menus/menu-welcome.php:692
+#: menus/menu-welcome.php:696
 msgid ""
 "Publish a test \"Property Listing\" and visit your new property page and you will see "
 "the new property and others you have created."
 msgstr ""
 
-#: menus/menu-welcome.php:694
+#: menus/menu-welcome.php:698
 msgid ""
 "Now you can rename them to whatever you like eg: \"For Sale\", \"For Rent\" etc, but "
 "leave the slug/permalink as it was,"
 msgstr ""
 
-#: menus/menu-welcome.php:694
+#: menus/menu-welcome.php:698
 msgid "this is very important."
 msgstr ""
 
-#: menus/menu-welcome.php:707
+#: menus/menu-welcome.php:711
 msgid "Publish Your First Listing"
 msgstr ""
 
-#: menus/menu-welcome.php:712
+#: menus/menu-welcome.php:716
 msgid "Title & Author"
 msgstr ""
 
-#: menus/menu-welcome.php:719
+#: menus/menu-welcome.php:723
 msgid "Use the full listing address as the title."
 msgstr ""
 
-#: menus/menu-welcome.php:721
+#: menus/menu-welcome.php:725
 msgid ""
 "When a property is being sold the \"heading\" is frequently changed and can cause "
 "permalink issues. Not to mention the search engine benefits."
 msgstr ""
 
-#: menus/menu-welcome.php:723
+#: menus/menu-welcome.php:727
 msgid "Author or Primary Real Estate Agent"
 msgstr ""
 
-#: menus/menu-welcome.php:724
+#: menus/menu-welcome.php:728
 msgid ""
 "Select the author to show the name of the agent who has listed the property with "
 "their contact details. For best results each real estate agent should have their own "
@@ -3115,258 +3133,258 @@ msgid ""
 "and in widgets."
 msgstr ""
 
-#: menus/menu-welcome.php:733
+#: menus/menu-welcome.php:737
 msgid "Gallery and Featured Image"
 msgstr ""
 
-#: menus/menu-welcome.php:738
+#: menus/menu-welcome.php:742
 msgid "Gallery"
 msgstr ""
 
-#: menus/menu-welcome.php:741
+#: menus/menu-welcome.php:745
 msgid "You can automatically output a gallery from the Display options page."
 msgstr ""
 
-#: menus/menu-welcome.php:743
+#: menus/menu-welcome.php:747
 msgid ""
 "If set to automatic, just upload your images to the listing and press x to close the "
 "media upload box once the images are attached to the listing. You can also easily "
 "adjust the number of gallery columns from the plugin Display options."
 msgstr ""
 
-#: menus/menu-welcome.php:745
+#: menus/menu-welcome.php:749
 msgid "Gallery Light Box"
 msgstr ""
 
-#: menus/menu-welcome.php:746
+#: menus/menu-welcome.php:750
 msgid ""
 "Using a light box plug-in like Easy FancyBox, your automatic gallery images will use "
 "the light box effect."
 msgstr ""
 
-#: menus/menu-welcome.php:770
+#: menus/menu-welcome.php:774
 msgid ""
 "Now supports multiple inspection times, add one per line. Past inspection dates will "
 "not display when using the new format."
 msgstr ""
 
-#: menus/menu-welcome.php:772
+#: menus/menu-welcome.php:776
 msgid ""
 "The output is now wrapped in an iCal format so clicking on the date will open the "
 "users calendar."
 msgstr ""
 
-#: menus/menu-welcome.php:785
+#: menus/menu-welcome.php:789
 msgid "Configure your theme"
 msgstr ""
 
-#: menus/menu-welcome.php:786
+#: menus/menu-welcome.php:790
 msgid ""
 "If you have never looked at a line of code in your life and you can copy and paste "
 "you can do this.<br/>We have made this process as easy as possible."
 msgstr ""
 
-#: menus/menu-welcome.php:791
+#: menus/menu-welcome.php:795
 msgid "Overview"
 msgstr ""
 
-#: menus/menu-welcome.php:792
+#: menus/menu-welcome.php:796
 msgid ""
 "WordPress has filters and hooks for \"the_title\" and \"the_content\" but these are "
 "not applicable for real estate websites where the address, price bed/bath icons and "
 "maps are much more important than categories, date and published by info."
 msgstr ""
 
-#: menus/menu-welcome.php:794
+#: menus/menu-welcome.php:798
 msgid ""
 "Not performing the setup steps may cause your sidebar to appear in the wrong place or "
 "the listing pages appear too wide."
 msgstr ""
 
-#: menus/menu-welcome.php:796
+#: menus/menu-welcome.php:800
 msgid "Solution"
 msgstr ""
 
-#: menus/menu-welcome.php:798
+#: menus/menu-welcome.php:802
 msgid ""
 "All you have to do is duplicate some files and copy and paste into them. If all else "
 "fails you can use the included shortcodes but these are not nearly as good as "
 "implementing the following steps."
 msgstr ""
 
-#: menus/menu-welcome.php:803
+#: menus/menu-welcome.php:807
 msgid "<h4>No configuration required for some themes"
 msgstr ""
 
-#: menus/menu-welcome.php:810
+#: menus/menu-welcome.php:814
 msgid "We have a selection of pre configured templates here for many popular themes"
 msgstr ""
 
-#: menus/menu-welcome.php:810
+#: menus/menu-welcome.php:814
 msgid "here"
 msgstr ""
 
-#: menus/menu-welcome.php:812
+#: menus/menu-welcome.php:816
 msgid "Future"
 msgstr ""
 
-#: menus/menu-welcome.php:813
+#: menus/menu-welcome.php:817
 msgid ""
 "We hope a future WordPress release adds filter so this can be automatic, but until "
 "that happens you are going to have to perform the following steps using copy and "
 "paste."
 msgstr ""
 
-#: menus/menu-welcome.php:819
+#: menus/menu-welcome.php:823
 msgid "Manual configuration instructions"
 msgstr ""
 
-#: menus/menu-welcome.php:820
+#: menus/menu-welcome.php:824
 msgid "Before attempting the following steps add a"
 msgstr ""
 
-#: menus/menu-welcome.php:820
+#: menus/menu-welcome.php:824
 msgid "test listing"
 msgstr ""
 
-#: menus/menu-welcome.php:820
+#: menus/menu-welcome.php:824
 msgid "and preview it. Your theme may already work with Easy Property Listings."
 msgstr ""
 
-#: menus/menu-welcome.php:824
+#: menus/menu-welcome.php:828
 msgid "1. Take a backup of your theme and a copy of the files to edit."
 msgstr ""
 
-#: menus/menu-welcome.php:826
+#: menus/menu-welcome.php:830
 msgid ""
 "Open your favourite FTP program or access the file manager via your hosting panel."
 msgstr ""
 
-#: menus/menu-welcome.php:828
+#: menus/menu-welcome.php:832
 msgid "Take a backup of your theme before you start."
 msgstr ""
 
-#: menus/menu-welcome.php:830
+#: menus/menu-welcome.php:834
 msgid ""
 "Download the single.php file and archive.php from your theme folder and save it to "
 "your computer."
 msgstr ""
 
-#: menus/menu-welcome.php:831
+#: menus/menu-welcome.php:835
 msgid ""
 "If these files are not present in your child theme then copy them from your parent "
 "theme folder. If there is no archive.php file use the index.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:834
+#: menus/menu-welcome.php:838
 msgid ""
 "On your computer rename single.php to single-listing.php and rename archive.php to "
 "archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:836
+#: menus/menu-welcome.php:840
 msgid "If using index.php, rename that to archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:838
+#: menus/menu-welcome.php:842
 msgid "Upload these new files back into your theme folder."
 msgstr ""
 
-#: menus/menu-welcome.php:842
+#: menus/menu-welcome.php:846
 msgid "2. Edit your single-listing.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:844
+#: menus/menu-welcome.php:848
 msgid "Open your new single-listing.php file in your text editor like Notepad++."
 msgstr ""
 
-#: menus/menu-welcome.php:845 menus/menu-welcome.php:862
+#: menus/menu-welcome.php:849 menus/menu-welcome.php:866
 msgid "Look for"
 msgstr ""
 
-#: menus/menu-welcome.php:846
+#: menus/menu-welcome.php:850
 msgid "which appears after"
 msgstr ""
 
-#: menus/menu-welcome.php:847 menus/menu-welcome.php:866
+#: menus/menu-welcome.php:851 menus/menu-welcome.php:870
 msgid "Replace"
 msgstr ""
 
-#: menus/menu-welcome.php:850
+#: menus/menu-welcome.php:854
 msgid "with"
 msgstr ""
 
-#: menus/menu-welcome.php:853 menus/menu-welcome.php:872
+#: menus/menu-welcome.php:857 menus/menu-welcome.php:876
 msgid "Save the file and make sure you have sent it to the server."
 msgstr ""
 
-#: menus/menu-welcome.php:854
+#: menus/menu-welcome.php:858
 msgid "View the test listing you created and you should be done."
 msgstr ""
 
-#: menus/menu-welcome.php:859
+#: menus/menu-welcome.php:863
 msgid "3. Edit your archive-listing.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:861
+#: menus/menu-welcome.php:865
 msgid "Open archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:863
+#: menus/menu-welcome.php:867
 msgid "which appears after the second"
 msgstr ""
 
-#: menus/menu-welcome.php:864
+#: menus/menu-welcome.php:868
 msgid "The first one is usually the page title."
 msgstr ""
 
-#: menus/menu-welcome.php:873
+#: menus/menu-welcome.php:877
 msgid ""
 "Check the main property page <code>http://YOUR_SITE_URL/property/</code> and you "
 "should be done."
 msgstr ""
 
-#: menus/menu-welcome.php:878
+#: menus/menu-welcome.php:882
 msgid "4. Optional for grid and sorter. Edit your archive-listing.php file again."
 msgstr ""
 
-#: menus/menu-welcome.php:880 menus/menu-welcome.php:887
+#: menus/menu-welcome.php:884 menus/menu-welcome.php:891
 msgid "Insert"
 msgstr ""
 
-#: menus/menu-welcome.php:883
+#: menus/menu-welcome.php:887
 msgid "Before the second"
 msgstr ""
 
-#: menus/menu-welcome.php:885
+#: menus/menu-welcome.php:889
 msgid ""
 "Check your main property page, if the buttons are in the incorrect place move them "
 "until they are in the correct place."
 msgstr ""
 
-#: menus/menu-welcome.php:888
+#: menus/menu-welcome.php:892
 msgid "After the second"
 msgstr ""
 
-#: menus/menu-welcome.php:896
+#: menus/menu-welcome.php:900
 msgid "Stuck getting your theme to work?"
 msgstr ""
 
-#: menus/menu-welcome.php:897
+#: menus/menu-welcome.php:901
 msgid ""
 "Not all themes follow modern WordPress coding standards and these may take a little "
 "more time and experience to get working. If you just can not get it to work, visit"
 msgstr ""
 
-#: menus/menu-welcome.php:897
+#: menus/menu-welcome.php:901
 msgid "support"
 msgstr ""
 
-#: menus/menu-welcome.php:897
+#: menus/menu-welcome.php:901
 msgid "desk and fill out a theme support request."
 msgstr ""
 
-#: menus/menu-welcome.php:899
+#: menus/menu-welcome.php:903
 msgid ""
 "If the theme is available in the WordPress.org theme directory let us know the theme "
 "name and URL where we can download it in your support ticket. If its a premium theme "
@@ -3374,61 +3392,61 @@ msgid ""
 "link to it on a file sharing site like Dropbox."
 msgstr ""
 
-#: menus/menu-welcome.php:901
+#: menus/menu-welcome.php:905
 msgid "Need Help?"
 msgstr ""
 
-#: menus/menu-welcome.php:906
+#: menus/menu-welcome.php:910
 msgid "Phenomenal Support"
 msgstr ""
 
-#: menus/menu-welcome.php:907
+#: menus/menu-welcome.php:911
 #, php-format
 msgid ""
 "We do our best to provide the best support we can. If you encounter a problem or have "
 "a question, post a question in the <a href=\"%s\">support forums</a>."
 msgstr ""
 
-#: menus/menu-welcome.php:911
+#: menus/menu-welcome.php:915
 msgid "Need Even Faster Support?"
 msgstr ""
 
-#: menus/menu-welcome.php:912
+#: menus/menu-welcome.php:916
 msgid ""
 "Visit the <a href=\"http://easypropertylistings.com.au/support/pricing/\">Priority "
 "Support forums</a> are there for customers that need faster and/or more in-depth "
 "assistance."
 msgstr ""
 
-#: menus/menu-welcome.php:916
+#: menus/menu-welcome.php:920
 msgid "Documentation and Short Codes"
 msgstr ""
 
-#: menus/menu-welcome.php:917
+#: menus/menu-welcome.php:921
 msgid "Read the"
 msgstr ""
 
-#: menus/menu-welcome.php:917
+#: menus/menu-welcome.php:921
 msgid "documentation"
 msgstr ""
 
-#: menus/menu-welcome.php:917
+#: menus/menu-welcome.php:921
 msgid " and instructions on how to use the included"
 msgstr ""
 
-#: menus/menu-welcome.php:917
+#: menus/menu-welcome.php:921
 msgid "shortcodes"
 msgstr ""
 
-#: menus/menu-welcome.php:926
+#: menus/menu-welcome.php:930
 msgid "Stay Up to Date"
 msgstr ""
 
-#: menus/menu-welcome.php:927
+#: menus/menu-welcome.php:931
 msgid "Get Notified of Extension Releases"
 msgstr ""
 
-#: menus/menu-welcome.php:928
+#: menus/menu-welcome.php:932
 msgid ""
 "New extensions that make Easy Property Listings even more powerful are released "
 "nearly every single week. Subscribe to the newsletter to stay up to date with our "
@@ -3436,53 +3454,53 @@ msgid ""
 "a> to ensure you do not miss a release!"
 msgstr ""
 
-#: menus/menu-welcome.php:930
+#: menus/menu-welcome.php:934
 msgid "Get Alerted About New Tutorials"
 msgstr ""
 
-#: menus/menu-welcome.php:931
+#: menus/menu-welcome.php:935
 msgid ""
 "<a href=\"http://eepurl.com/TRO9f\" target=\"_blank\">Sign up now</a> to hear about "
 "the latest tutorial releases that explain how to take Easy Property Listings further."
 msgstr ""
 
-#: menus/menu-welcome.php:935
+#: menus/menu-welcome.php:939
 msgid "Extend With Extensions"
 msgstr ""
 
-#: menus/menu-welcome.php:936
+#: menus/menu-welcome.php:940
 msgid "12 Extensions and many more coming"
 msgstr ""
 
-#: menus/menu-welcome.php:937
+#: menus/menu-welcome.php:941
 msgid ""
 "Add-on plug ins are available that greatly extend the default functionality of Easy "
 "Property Listings. There are extensions for Advanced mapping, testimonials, listing "
 "alerts, CMA Market Reports, Location Profiles, and many, many more."
 msgstr ""
 
-#: menus/menu-welcome.php:939
+#: menus/menu-welcome.php:943
 msgid "Visit the Extension Store"
 msgstr ""
 
-#: menus/menu-welcome.php:940
+#: menus/menu-welcome.php:944
 msgid "The Extensions store"
 msgstr ""
 
-#: menus/menu-welcome.php:940
+#: menus/menu-welcome.php:944
 msgid ""
 "has a list of all available extensions, including convenient category filters so you "
 "can find exactly what you are looking for."
 msgstr ""
 
-#: menus/menu-welcome.php:965
+#: menus/menu-welcome.php:969
 msgid ""
 "Easy Property Listings is created by a worldwide team of developers who aim to "
 "provide the #1 property listings platform for managing your real estate business "
 "through WordPress."
 msgstr ""
 
-#: menus/menu-welcome.php:992
+#: menus/menu-welcome.php:996
 #, php-format
 msgid "View %s"
 msgstr ""
@@ -3526,6 +3544,7 @@ msgstr ""
 #: post-types/post-type-rental.php:253 post-types/post-type-rural.php:259
 #: post-types/post-types.php:39 widgets/widget-admin-dashboard.php:99
 #: widgets/widget-admin-dashboard.php:116 widgets/widget-admin-dashboard.php:138
+#: widgets/widget-listing-search.php:162
 msgid "Current"
 msgstr ""
 
@@ -3684,8 +3703,8 @@ msgstr ""
 msgid "Authority"
 msgstr ""
 
-#: meta-boxes/meta-boxes.php:184 shortcodes/shortcode-listing-search.php:166
-#: widgets/widget-listing-search.php:159
+#: meta-boxes/meta-boxes.php:184 shortcodes/shortcode-listing-search.php:178
+#: widgets/widget-listing-search.php:184
 msgid "House Category"
 msgstr ""
 
@@ -3801,7 +3820,7 @@ msgstr ""
 msgid "Year Built"
 msgstr ""
 
-#: meta-boxes/meta-boxes.php:373 shortcodes/shortcode-listing-search.php:637
+#: meta-boxes/meta-boxes.php:373 shortcodes/shortcode-listing-search.php:649
 msgid "Security System"
 msgstr ""
 
@@ -3810,7 +3829,7 @@ msgid "Land Details"
 msgstr ""
 
 #: meta-boxes/meta-boxes.php:390 meta-boxes/meta-boxes.php:765
-#: widgets/widget-listing-search.php:183
+#: widgets/widget-listing-search.php:208
 msgid "Land Area"
 msgstr ""
 
@@ -3819,7 +3838,7 @@ msgid "Land Unit"
 msgstr ""
 
 #: meta-boxes/meta-boxes.php:404 meta-boxes/meta-boxes.php:779
-#: widgets/widget-listing-search.php:187
+#: widgets/widget-listing-search.php:212
 msgid "Building Area"
 msgstr ""
 
@@ -4164,7 +4183,7 @@ msgstr ""
 #: post-types/post-type-business.php:84 post-types/post-type-commercial.php:82
 #: post-types/post-type-commercial_land.php:83 post-types/post-type-land.php:83
 #: post-types/post-type-property.php:83 post-types/post-type-rural.php:83
-#: widgets/widget-listing-search.php:163 widgets/widget-listing.php:387
+#: widgets/widget-listing-search.php:188 widgets/widget-listing.php:387
 msgid "Price"
 msgstr ""
 
@@ -4539,55 +4558,55 @@ msgid "Nothing currently scheduled for inspection, please check back later."
 msgstr ""
 
 #: shortcodes/shortcode-listing-search.php:42
-#: shortcodes/shortcode-listing-search.php:647 widgets/widget-listing-search.php:36
-#: widgets/widget-listing-search.php:87
+#: shortcodes/shortcode-listing-search.php:659 widgets/widget-listing-search.php:37
+#: widgets/widget-listing-search.php:90
 msgid "Find me a Property!"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:105
+#: shortcodes/shortcode-listing-search.php:117
 msgid "Search by Property ID / Address"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:146
-#: shortcodes/shortcode-listing-search.php:185
-#: shortcodes/shortcode-listing-search.php:285
-#: shortcodes/shortcode-listing-search.php:305
-#: shortcodes/shortcode-listing-search.php:331
-#: shortcodes/shortcode-listing-search.php:365
-#: shortcodes/shortcode-listing-search.php:406
-#: shortcodes/shortcode-listing-search.php:435
-#: shortcodes/shortcode-listing-search.php:464
+#: shortcodes/shortcode-listing-search.php:158
+#: shortcodes/shortcode-listing-search.php:197
+#: shortcodes/shortcode-listing-search.php:297
+#: shortcodes/shortcode-listing-search.php:317
+#: shortcodes/shortcode-listing-search.php:343
+#: shortcodes/shortcode-listing-search.php:377
+#: shortcodes/shortcode-listing-search.php:418
+#: shortcodes/shortcode-listing-search.php:447
+#: shortcodes/shortcode-listing-search.php:476 widgets/widget-listing-search.php:161
 msgid "Any"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:281
+#: shortcodes/shortcode-listing-search.php:293
 msgid "Price From"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:301
+#: shortcodes/shortcode-listing-search.php:313
 msgid "To"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:327
+#: shortcodes/shortcode-listing-search.php:339
 msgid "Bedrooms Min"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:361
-#: shortcodes/shortcode-listing-search.php:509
-#: shortcodes/shortcode-listing-search.php:573
+#: shortcodes/shortcode-listing-search.php:373
+#: shortcodes/shortcode-listing-search.php:521
+#: shortcodes/shortcode-listing-search.php:585
 msgid "Max"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:495
+#: shortcodes/shortcode-listing-search.php:507
 msgid "Land Min"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:524
-#: shortcodes/shortcode-listing-search.php:587
+#: shortcodes/shortcode-listing-search.php:536
+#: shortcodes/shortcode-listing-search.php:599
 msgid "Area Unit"
 msgstr ""
 
-#: shortcodes/shortcode-listing-search.php:559
+#: shortcodes/shortcode-listing-search.php:571
 msgid "Building Min"
 msgstr ""
 
@@ -4867,7 +4886,7 @@ msgid "EPL - Author"
 msgstr ""
 
 #: widgets/widget-author.php:77 widgets/widget-listing-gallery.php:62
-#: widgets/widget-listing-search.php:109
+#: widgets/widget-listing-search.php:113
 msgid "Title:"
 msgstr ""
 
@@ -4895,35 +4914,51 @@ msgstr ""
 msgid "EPL - Listing Search"
 msgstr ""
 
-#: widgets/widget-listing-search.php:114
+#: widgets/widget-listing-search.php:118
+msgid "Style"
+msgstr ""
+
+#: widgets/widget-listing-search.php:122
+msgid "Default"
+msgstr ""
+
+#: widgets/widget-listing-search.php:123
+msgid "Wide"
+msgstr ""
+
+#: widgets/widget-listing-search.php:124
+msgid "Slim"
+msgstr ""
+
+#: widgets/widget-listing-search.php:139
 msgid "Listing Type, hold CTRL to select multiple and enable tabs"
 msgstr ""
 
-#: widgets/widget-listing-search.php:132
+#: widgets/widget-listing-search.php:157
 msgid "Status:"
 msgstr ""
 
-#: widgets/widget-listing-search.php:155
+#: widgets/widget-listing-search.php:180
 msgid "Property ID"
 msgstr ""
 
-#: widgets/widget-listing-search.php:167
+#: widgets/widget-listing-search.php:192
 msgid "Bedroom"
 msgstr ""
 
-#: widgets/widget-listing-search.php:171
+#: widgets/widget-listing-search.php:196
 msgid "Bathroom"
 msgstr ""
 
-#: widgets/widget-listing-search.php:179
+#: widgets/widget-listing-search.php:204
 msgid "Car"
 msgstr ""
 
-#: widgets/widget-listing-search.php:192
+#: widgets/widget-listing-search.php:217
 msgid "Other Search Options"
 msgstr ""
 
-#: widgets/widget-listing-search.php:195
+#: widgets/widget-listing-search.php:220
 msgid "Submit Label:"
 msgstr ""
 

--- a/lib/menus/index.php
+++ b/lib/menus/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -301,6 +301,7 @@ class EPL_Welcome {
 						<li><?php _e( 'New: listing_search shortcode now has style option for adjusting the width. You can add style="slim" or style="wide" to the shortcode to adjust the appearance.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Updated translation and added missing sqm translation element.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Allowed for hundredths decimal in bathrooms field.', 'epl' );?></li>
+						<li><?php _e( 'Tweak: Floor plan button CSS.', 'epl' );?></li>
 						<li><?php _e( 'Fix: Auction listing price set to no displays auction date correctly.', 'epl' );?></li>
 					</ul>
 					

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -299,6 +299,7 @@ class EPL_Welcome {
 
 					<ul>
 						<li><?php _e( 'New: listing_search shortcode now has style option for adjusting the width. You can add style="slim" or style="wide" to the shortcode to adjust the appearance.', 'epl' );?></li>
+						<li><?php _e( 'New: Listing Search widget now has style options for adjusting the width.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Updated translation and added missing sqm translation element.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Allowed for hundredths decimal in bathrooms field.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Floor plan button CSS.', 'epl' );?></li>

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -302,6 +302,7 @@ class EPL_Welcome {
 						<li><?php _e( 'Tweak: Updated translation and added missing sqm translation element.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Allowed for hundredths decimal in bathrooms field.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Floor plan button CSS.', 'epl' );?></li>
+						<li><?php _e( 'Tweak: Address and price responsive CSS.', 'epl' );?></li>
 						<li><?php _e( 'Fix: Auction listing price set to no displays auction date correctly.', 'epl' );?></li>
 					</ul>
 					

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -304,6 +304,7 @@ class EPL_Welcome {
 						<li><?php _e( 'Tweak: Floor plan button CSS.', 'epl' );?></li>
 						<li><?php _e( 'Tweak: Address and price responsive CSS.', 'epl' );?></li>
 						<li><?php _e( 'Fix: Auction listing price set to no displays auction date correctly.', 'epl' );?></li>
+						<li><?php _e( 'Fix: Fix: Author position css class.', 'epl' );?></li>
 					</ul>
 					
 					<h4><?php _e( 'Version 2.1.6', 'epl' );?></h4>

--- a/lib/meta-boxes/index.php
+++ b/lib/meta-boxes/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/post-types/index.php
+++ b/lib/post-types/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/shortcodes/index.php
+++ b/lib/shortcodes/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/shortcodes/shortcode-listing-search.php
+++ b/lib/shortcodes/shortcode-listing-search.php
@@ -28,7 +28,7 @@ function epl_shortcode_listing_search_callback( $atts ) {
 		'title'				=>	'', 	// Freeform text
 		'post_type'			=>	array('property'), // Post type name array
 		'property_status'		=>	'', 	// Singular: current / sold / leased or '' for any
-		'style'				=>	'', 	// Singular: blank value or "wide" or "slim"
+		'style'				=>	'default', 	// Singular: "default", "wide" or "slim"
 		'search_house_category'		=>	'on', 	// on or off
 		'search_price'			=>	'on', 	// on or off
 		'search_bed'			=>	'on', 	// on or off
@@ -51,23 +51,12 @@ function epl_shortcode_listing_search_callback( $atts ) {
 		$selected_post_types = array_map('trim', $selected_post_types);
 	}
 	
-	// Search Widget Class
-	if ( isset( $style ) ) {
-		if ( $style == 'wide' )
-			$search_class = 'epl-search-wide';
-			
-		elseif ( $style == 'slim' )
-			$search_class = 'epl-search-slim';
-			
-		else $search_class = '';
-	}
-	
 	global $epl_settings;
 	ob_start();	
 	$tabcounter = 1;
 	if(!empty($selected_post_types)):
 		if(count($selected_post_types) > 1):
-			echo "<ul class='epl-search-tabs property_search-tabs $search_class'>";
+			echo "<ul class='epl-search-tabs property_search-tabs epl-search-$style'>";
 			foreach($selected_post_types as $post_type):
 	
 				if( isset($_GET['action'] ) && $_GET['action'] == 'epl_search' ) {
@@ -89,7 +78,7 @@ function epl_shortcode_listing_search_callback( $atts ) {
 		endif;
 
 	?>
-	<div class="epl-search-forms-wrapper <?php echo $search_class; ?>">
+	<div class="epl-search-forms-wrapper epl-search-<?php echo $style; ?>">
 		<?php
 			$tabcounter = 1; // reset tab counter
 

--- a/lib/taxonomies/index.php
+++ b/lib/taxonomies/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/templates/content/archive-listing.php
+++ b/lib/templates/content/archive-listing.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Archive Template for Property Custom Post Type : property
  */
 

--- a/lib/templates/content/author-meta.php
+++ b/lib/templates/content/author-meta.php
@@ -1,8 +1,8 @@
 <?php
 /*
-*	This file is depricated and will be removed in future.
-*	It is advised to follow the updated documentation for the alternatives for the current version of plugin
-*	@deprecated deprecated since version 1.3
-*/
+ * This file is deprecated and will be removed in future.
+ * It is advised to follow the updated documentation for the alternatives for the current version of plugin
+ * @deprecated deprecated since version 1.3
+ */
 include(EPL_COMPATABILITY . 'author-meta-compat.php' );
 

--- a/lib/templates/content/author.php
+++ b/lib/templates/content/author.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Archive Template for Author Profile : author.php
  */
 

--- a/lib/templates/content/content-author-box-simple-card.php
+++ b/lib/templates/content/content-author-box-simple-card.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Author Box: Simple Card
  *
  * @package easy-property-listings

--- a/lib/templates/content/content-author-box-simple-grav.php
+++ b/lib/templates/content/content-author-box-simple-grav.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Author Box: Simple Card Gravatar Image
  *
  * @package easy-property-listings

--- a/lib/templates/content/content-author-box.php
+++ b/lib/templates/content/content-author-box.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Author Box: Advanced Style
  *
  * @package EPL

--- a/lib/templates/content/content-listing-search.php
+++ b/lib/templates/content/content-listing-search.php
@@ -1,4 +1,7 @@
 <?php
+/*
+ * Search Widget Content.
+ */
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/lib/templates/content/index.php
+++ b/lib/templates/content/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/templates/content/loop-listing-blog-default.php
+++ b/lib/templates/content/loop-listing-blog-default.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Loop Property Template: Default
  *
  * @package easy-property-listings

--- a/lib/templates/content/loop-listing-blog-slim.php
+++ b/lib/templates/content/loop-listing-blog-slim.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Loop Property Template: Slim home open list
  *
  * @package easy-property-listings

--- a/lib/templates/content/loop-listing-blog-table.php
+++ b/lib/templates/content/loop-listing-blog-table.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Loop Property Template: Table
  *
  * @package easy-property-listings

--- a/lib/templates/content/single-listing.php
+++ b/lib/templates/content/single-listing.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Single Template for Property Custom Post Type : property
  */
 

--- a/lib/templates/content/widget-content-author-tall.php
+++ b/lib/templates/content/widget-content-author-tall.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Author Card used in Widget
  *
  * @package easy-property-listings

--- a/lib/templates/index.php
+++ b/lib/templates/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/templates/themes/default/archive-listing.php
+++ b/lib/templates/themes/default/archive-listing.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Archive Template for Custom Post Types
-**/
+ */
  
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/lib/templates/themes/index.php
+++ b/lib/templates/themes/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/templates/themes/ithemes-builder/single-listing.php
+++ b/lib/templates/themes/ithemes-builder/single-listing.php
@@ -1,5 +1,4 @@
 <?php
-
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 

--- a/lib/templates/themes/themes.php
+++ b/lib/templates/themes/themes.php
@@ -1,5 +1,5 @@
 <?php
-/* 
+/**
  * Loading the templates
  * Needs to work with other themes. These template files af a function that iThemes Builder needs to render the template.
  */

--- a/lib/widgets/index.php
+++ b/lib/widgets/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Do not modify the files in this folder.
  */

--- a/lib/widgets/widget-listing-search.php
+++ b/lib/widgets/widget-listing-search.php
@@ -22,6 +22,7 @@ class EPL_Widget_Property_Search extends WP_Widget {
 		$defaults = array(
 			'title'				=>	'',
 			'post_type'			=>	array('property'),
+			'style'				=>	'default',
 			'property_status'		=>	'any',
 			'search_house_category'		=>	'on',
 			'search_price'			=>	'on',
@@ -55,6 +56,7 @@ class EPL_Widget_Property_Search extends WP_Widget {
 		$instance['title'] = strip_tags($new_instance['title']);
 		$instance['post_type'] = $new_instance['post_type'];
 		$instance['property_status'] = strip_tags($new_instance['property_status']);
+		$instance['style'] = strip_tags($new_instance['style']);
 		$instance['search_house_category'] = strip_tags($new_instance['search_house_category']);
 		$instance['search_price'] = strip_tags($new_instance['search_price']);
 		$instance['search_bed'] = strip_tags($new_instance['search_bed']);
@@ -73,6 +75,7 @@ class EPL_Widget_Property_Search extends WP_Widget {
 		$defaults = array(
 			'title'				=>	'',
 			'post_type'			=>	array('property'),
+			'style'				=>	'default',
 			'property_status'		=>	'any',
 			'search_house_category'		=>	'on',
 			'search_price'			=>	'on',
@@ -92,6 +95,7 @@ class EPL_Widget_Property_Search extends WP_Widget {
 		$post_types		=	$instance['post_type'];
 
 		$property_status	=	esc_attr($instance['property_status']);
+		$style			=	esc_attr($instance['style']);
 		$search_house_category	=	esc_attr($instance['search_house_category']);
 		$search_price		=	esc_attr($instance['search_price']);
 		$search_bed		=	esc_attr($instance['search_bed']);
@@ -108,6 +112,27 @@ class EPL_Widget_Property_Search extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:', 'epl'); ?></label> 
 			<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo $title; ?>" />
+		</p>
+		
+		<p>
+			<label for="<?php echo $this->get_field_id('style'); ?>"><?php _e('Style', 'epl'); ?></label> 
+			<select class="widefat" id="<?php echo $this->get_field_id('style'); ?>" name="<?php echo $this->get_field_name('style'); ?>">
+				<?php
+					$status_list = array(
+						'default'	=>	__('Default' , 'epl'),
+						'wide'		=>	__('Wide' , 'epl'),
+						'slim'		=>	__('Slim' , 'epl')
+					);
+					
+					foreach($status_list as $k=>$v) {
+						$selected = '';
+						if(isset($style) && $k == $style) {
+							$selected = 'selected="selected"';
+						}
+						echo '<option value="'.$k.'" '.$selected.'>'.__($v, 'epl').'</option>';
+					}
+				?>
+			</select>
 		</p>
 		
 		<p>
@@ -133,10 +158,10 @@ class EPL_Widget_Property_Search extends WP_Widget {
 			<select class="widefat" id="<?php echo $this->get_field_id('property_status'); ?>" name="<?php echo $this->get_field_name('property_status'); ?>">
 				<?php
 					$status_list = array(
-						''		=>	'Any',
-						'current'	=>	'Current',
-						'sold'		=>	'Sold',
-						'leased'	=>	'Leased'
+						''		=>	__('Any' , 'epl'),
+						'current'	=>	__('Current' , 'epl'),
+						'sold'		=>	__('Sold' , 'epl'),
+						'leased'	=>	__('Leased' , 'epl')
 					);
 					
 					foreach($status_list as $k=>$v) {

--- a/readme.txt
+++ b/readme.txt
@@ -157,7 +157,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
-= 2.1.7 May 5, 2015 =
+= 2.1.7 May 6, 2015 =
 
 * New: listing_search shortcode now has style option for adjusting the width. You can add style="slim" or style="wide" to the shortcode to adjust the appearance.
 * Tweak: Updated translation epl.pot and added missing sqm translation element.
@@ -165,6 +165,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 * Tweak: Floor plan button CSS.
 * Tweak: Address and price responsive CSS.
 * Fix: Auction listing price set to no displays auction date correctly.
+* Fix: Fix: Author position css class.
 
 = 2.1.6 May 1, 2015 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -163,6 +163,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 * Tweak: Updated translation epl.pot and added missing sqm translation element.
 * Tweak: Allowed for hundredths decimal in bathrooms field.
 * Tweak: Floor plan button CSS.
+* Tweak: Address and price responsive CSS.
 * Fix: Auction listing price set to no displays auction date correctly.
 
 = 2.1.6 May 1, 2015 =

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 * New: listing_search shortcode now has style option for adjusting the width. You can add style="slim" or style="wide" to the shortcode to adjust the appearance.
 * Tweak: Updated translation epl.pot and added missing sqm translation element.
 * Tweak: Allowed for hundredths decimal in bathrooms field.
+* Tweak: Floor plan button CSS.
 * Fix: Auction listing price set to no displays auction date correctly.
 
 = 2.1.6 May 1, 2015 =

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 = 2.1.7 May 6, 2015 =
 
 * New: listing_search shortcode now has style option for adjusting the width. You can add style="slim" or style="wide" to the shortcode to adjust the appearance.
+* New: Listing Search widget now has style options for adjusting the width.
 * Tweak: Updated translation epl.pot and added missing sqm translation element.
 * Tweak: Allowed for hundredths decimal in bathrooms field.
 * Tweak: Floor plan button CSS.


### PR DESCRIPTION
New: listing_search shortcode now has style option for adjusting the width. You can add style="slim" or style="wide" to the shortcode to adjust the appearance.
New: Listing Search widget now has style options for adjusting the width.
Tweak: Updated translation epl.pot and added missing sqm translation element.
Tweak: Allowed for hundredths decimal in bathrooms field.
Tweak: Floor plan button CSS.
Tweak: Address and price responsive CSS.
Fix: Auction listing price set to no displays auction date correctly.
Fix: Fix: Author position css class.